### PR TITLE
Rename getline to getLine

### DIFF
--- a/bdf2bmp.c
+++ b/bdf2bmp.c
@@ -96,7 +96,7 @@ void checkEndian(void);
 void dwrite(const void *ptrP, int n, FILE *outP);
 void writeBmpFile(unsigned char *bitmapP, int spacing, int colchar, FILE *bmpP);
 void assignBitmap(unsigned char *bitmapP, char *glyphP, int sizeglyphP, struct boundingbox glyph, int dw);
-int getline(char* lineP, int max, FILE* inputP);
+int getLine(char* lineP, int max, FILE* inputP);
 unsigned char *readBdfFile(unsigned char *bitmapP, FILE *readP);
 void printhelp(void);
 int main(int argc, char *argv[]);
@@ -453,7 +453,7 @@ void assignBitmap(unsigned char *bitmapP, char *glyphP, int sizeglyphP, struct b
 /*
  * read oneline from textfile
  */
-int getline(char* lineP, int max, FILE* inputP){
+int getLine(char* lineP, int max, FILE* inputP){
         if (fgets(lineP, max, inputP) == NULL)
                 return 0;
         else
@@ -478,7 +478,7 @@ unsigned char *readBdfFile(unsigned char *bitmapP, FILE *readP){
         static int bdfflag = OFF; /* the given bdf-file is valid or not */
 
         while(1){
-                length = getline(sP, LINE_CHARMAX, readP);
+                length = getLine(sP, LINE_CHARMAX, readP);
                 if((bdfflag == OFF) && (length == 0)){
                         /* given input-file is not a bdf-file */
                         printf("error: input-file is not a bdf file\n");


### PR DESCRIPTION
Because the function 'getline' may be defined on a posix environment, it seems to be better to rename this. In fact, Mac OS X 10.8 needs this change to compile bdf2bmp.
